### PR TITLE
alternative design pattern, asyncpipes

### DIFF
--- a/frontend/LoanOut/src/app/features/home/home.page.html
+++ b/frontend/LoanOut/src/app/features/home/home.page.html
@@ -22,7 +22,7 @@
 
   <ion-accordion-group>
     <ion-accordion value="first">
-      <ion-item *ngFor="let equipment of equipmentService.equipments;"slot="header" color="secondary">
+      <ion-item *ngFor="let equipment of equipments | async;"slot="header" color="secondary">
         <ion-label>{{equipment.name}}</ion-label>
       </ion-item>
       <div class="ion-padding" slot="content">

--- a/frontend/LoanOut/src/app/features/home/home.page.ts
+++ b/frontend/LoanOut/src/app/features/home/home.page.ts
@@ -1,4 +1,7 @@
 import { Component, OnInit} from '@angular/core';
+import {Observable} from 'rxjs';
+import {Equipment} from 'src/app/models/equipment';
+import {Rent} from 'src/app/models/rent';
 import { EquipmentService } from 'src/app/services/equipment.service';
 import { RentService } from 'src/app/services/rent.service';
 import { AccountService } from 'src/app/services/user.service';
@@ -15,17 +18,19 @@ export class HomePage implements OnInit {
 	enterPinCode: boolean = false;
 	QrCode!: string;
 	pin!: string;
+  public equipments: Observable<Equipment[]>;
+  public rents: Observable<Rent[]>;
 	constructor(
 		public accountService: AccountService,
     public equipmentService: EquipmentService,
     public rentService: RentService,
   ) {
+    this.equipments = equipmentService.fetchEquipments(accountService.user?.organizationid || 0)
+    this.rents = rentService.fetchRentsByUser(accountService.user?.id || 0)
   }
 
-  ngOnInit() {
-    this.equipmentService.fetchEquipments(this.accountService.user?.organizationid || 0)
+  ngOnInit(): void {
 
-    this.rentService.fetchRentsByOrg(this.accountService.user?.organizationid || 0)
   }
 
   onOpenQrScanner() {

--- a/frontend/LoanOut/src/app/services/equipment.service.ts
+++ b/frontend/LoanOut/src/app/services/equipment.service.ts
@@ -6,13 +6,12 @@ import { HttpClient} from '@angular/common/http';
 @Injectable({ providedIn: 'root' })
 export class EquipmentService {
 
-    public equipments!: Equipment[];
     constructor(
         private http: HttpClient
     ) {
     }
     fetchEquipments(orgid: number)
     {
-        return this.http.get<Equipment[]>(`${environment.apiUrl}/equips/by_org/${orgid}`).subscribe(equips=>this.equipments = equips)
+        return this.http.get<Equipment[]>(`${environment.apiUrl}/equips/by_org/${orgid}`)
     }
 }

--- a/frontend/LoanOut/src/app/services/rent.service.ts
+++ b/frontend/LoanOut/src/app/services/rent.service.ts
@@ -6,17 +6,16 @@ import { HttpClient} from '@angular/common/http';
 @Injectable({ providedIn: 'root' })
 export class RentService {
 
-    public rents!: Rent[];
     constructor(
         private http: HttpClient
     ) {
     }
     fetchRentsByOrg(orgid: number)
     {
-        return this.http.get<Rent[]>(`${environment.apiUrl}/rents/by_org/${orgid}`).subscribe(rent => this.rents = rent)
+        return this.http.get<Rent[]>(`${environment.apiUrl}/rents/by_org/${orgid}`)
     }
     fetchRentsByUser(userid: number)
     {
-        return this.http.get<Rent[]>(`${environment.apiUrl}/rents/${userid}`).subscribe(rent => this.rents = rent)
+        return this.http.get<Rent[]>(`${environment.apiUrl}/rents/${userid}`)
     }
 }

--- a/frontend/LoanOut/src/environments/environment.ts
+++ b/frontend/LoanOut/src/environments/environment.ts
@@ -1,6 +1,6 @@
 
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:8888/api'
-  //apiUrl: 'http://172.105.74.176/api'
+  //apiUrl: 'http://localhost:8888/api'
+  apiUrl: 'http://172.105.74.176/api'
 };


### PR DESCRIPTION
services dont hold any data and lose their responsability to update and hold their data, now just serves the endpoints and observables which can then be piped in the frontend with angular async pipe operator. ref: https://angular.io/api/common/AsyncPipe

services no longer should be considered repositories and will not contain any data at all.

this solution contaminates the home page module quite a bit more but I imagine it can be optimized around this particular design pattern suggestion.